### PR TITLE
Clean-up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,41 +6,17 @@ Each exercise is created as a standalone Mix project requiring a varying degree 
 
 ## Exercises
 
-  - [Fizzbuzz](https://github.com/elixirschool/homework/tree/master/fizzbuzz)
-
-  >  Everyone's favorite!  Finish implementing Fizzbuzz in Elixir.
-
-  - [Shapes](https://github.com/elixirschool/homework/tree/master/shapes)
-
-  > Print different shapes to IO like diamonds, squares, and pyramids given their size.
-
-  - [String Cases](https://github.com/elixirschool/homework/tree/master/string_cases)
-
-  > In this exercise we'll implement functions to convert strings to CamelCase, snake_case, and WaVyCaSe.
-
-  - [Collections](https://github.com/elixirschool/homework/tree/master/collections)
-
-  > Implement multiple functions that manipulate and retrieve data from within collections.
-
-  - [Word Count](https://github.com/elixirschool/homework/tree/master/word_count)
-
-  > Using the provided poem _Be Proud of Who You Are_ (found within `word_count/priv`), count the occurrences of each word and print the top 10 most frequent.
-
-  - [Fibonacci](https://github.com/elixirschool/homework/tree/master/fibonacci)
-
-  > Print out _N_ steps of the Fibonacci sequence.
-
-  - [Markdown](https://github.com/elixirschool/homework/tree/master/markdown)
-
-  > Finish implementing a Markdown parser in Elixir
-
-  - [Palindrome](https://github.com/elixirschool/homework/tree/master/palindrome)
-
-  > Provided with a string of characters ("aabbc"), print all possible palindrome premutations ("abcba", "bacab") to IO.
-
-  - [Simple Bank](/tree/master/simple_bank) _added 2018-04-30_
-
-  > Build a bank using a GenServer to support account registration, deposits, withdrawls, and account balance inquiries.
+| Exercise             | Description           |
+|----------------------|-----------------------|
+|[Fizzbuzz](https://github.com/elixirschool/homework/tree/master/fizzbuzz)| Everyone's favorite!  Finish implementing Fizzbuzz in Elixir.|
+|[Shapes](https://github.com/elixirschool/homework/tree/master/shapes)|Print different shapes to IO like diamonds, squares, and pyramids given their size.|
+|[String Cases](https://github.com/elixirschool/homework/tree/master/string_cases)|In this exercise we'll implement functions to convert strings to CamelCase, snake_case, and WaVyCaSe.|
+|[Collections](https://github.com/elixirschool/homework/tree/master/collections)|Implement multiple functions that manipulate and retrieve data from within collections.|
+|[Word Count](https://github.com/elixirschool/homework/tree/master/word_count)|Using the provided poem _Be Proud of Who You Are_ (found within `word_count/priv`), count the occurrences of each word and print the top 10 most frequent.|
+|[Fibonacci](https://github.com/elixirschool/homework/tree/master/fibonacci)|Print out _N_ steps of the Fibonacci sequence.|
+|[Markdown](https://github.com/elixirschool/homework/tree/master/markdown)|Finish implementing a Markdown parser in Elixir.|
+|[Palindrome](https://github.com/elixirschool/homework/tree/master/palindrome)|Provided with a string of characters ("aabbc"), print all possible palindrome premutations ("abcba", "bacab") to IO.|
+|[Simple Bank](/tree/master/simple_bank)|Build a bank using a GenServer to support account registration, deposits, withdrawls, and account balance inquiries.|
 
 ## Contributions
 


### PR DESCRIPTION
Simple change.  Move the README to a table.  In the long term I want to find a way to incorporate this into the site.  Either by linking to these exercises in each lesson or generating a page in Jekyll using this as a source.