### PR TITLE
OTP Concurrency Homework

### DIFF
--- a/lessons/otp-concurrency/simple_bank/.formatter.exs
+++ b/lessons/otp-concurrency/simple_bank/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lessons/otp-concurrency/simple_bank/.gitignore
+++ b/lessons/otp-concurrency/simple_bank/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+simple_bank-*.tar
+

--- a/lessons/otp-concurrency/simple_bank/README.md
+++ b/lessons/otp-concurrency/simple_bank/README.md
@@ -1,0 +1,12 @@
+# Simple Bank
+
+In this homework assignment we're going to practice building a GenServer to mimic a bank.
+Our bank is expected to allow new accounts, deposits, withdrawls, and balance requests.
+
+We'll take a test-driven approach to this assignment by running the tests and using the failure output to guide us towards the code we need to write to get them passing.
+
+To run the tests, cd into `homework/lessons/otp-concurrency/simple_bank` and run:
+
+```shell
+$ mix test
+```

--- a/lessons/otp-concurrency/simple_bank/config/config.exs
+++ b/lessons/otp-concurrency/simple_bank/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure your application as:
+#
+#     config :simple_bank, key: :value
+#
+# and access this configuration in your application as:
+#
+#     Application.get_env(:simple_bank, :key)
+#
+# You can also configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/lessons/otp-concurrency/simple_bank/lib/simple_bank.ex
+++ b/lessons/otp-concurrency/simple_bank/lib/simple_bank.ex
@@ -4,15 +4,20 @@ defmodule SimpleBank do
   """
   use GenServer
 
+  @typedoc """
+   An atom describing an error
+   """
+   @type reason :: atom
+
   def start_link(initial_state \\ %{}) do
     GenServer.start_link(__MODULE__, initial_state)
   end
 
-  @spec register(pid(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec register(pid(), String.t()) :: {:ok, String.t()} | {:error, reason}
   def register(bank_pid, name) do
   end
 
-  @spec deposit(pid(), String.t(), pos_integer()) :: {:ok, pos_integer()} | {:error, String.t()}
+  @spec deposit(pid(), String.t(), pos_integer()) :: {:ok, pos_integer()} | {:error, reason}
   def deposit(bank_pid, account_id, amount) when is_integer(amount) and amount > 0 do
   end
 
@@ -20,11 +25,11 @@ defmodule SimpleBank do
     {:error, :missing_account}
   end
 
-  @spec deposit(pid(), String.t()) :: {:ok, pos_integer} | {:error, String.t()}
+  @spec balance(pid(), String.t()) :: {:ok, pos_integer} | {:error, reason}
   def balance(bank_pid, account_id) do
   end
 
-  @spec withdrawl(pid(), String.t(), pos_integer()) :: {:ok, {pos_integer(), pos_integer()}} | {:error, String.t()}
+  @spec withdrawl(pid(), String.t(), pos_integer()) :: {:ok, {pos_integer(), pos_integer()}} | {:error, reason}
   def withdrawl(bank_pid, account_id, amount) do
   end
 

--- a/lessons/otp-concurrency/simple_bank/lib/simple_bank.ex
+++ b/lessons/otp-concurrency/simple_bank/lib/simple_bank.ex
@@ -1,0 +1,34 @@
+defmodule SimpleBank do
+  @moduledoc """
+  SimpleBank is a GenServer charading as a bank.
+  """
+  use GenServer
+
+  def start_link(initial_state \\ %{}) do
+    GenServer.start_link(__MODULE__, initial_state)
+  end
+
+  @spec register(pid(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def register(bank_pid, name) do
+  end
+
+  @spec deposit(pid(), String.t(), pos_integer()) :: {:ok, pos_integer()} | {:error, String.t()}
+  def deposit(bank_pid, account_id, amount) when is_integer(amount) and amount > 0 do
+  end
+
+  def deposit(_bank_pid, _account_id, _amount) do
+    {:error, :missing_account}
+  end
+
+  @spec deposit(pid(), String.t()) :: {:ok, pos_integer} | {:error, String.t()}
+  def balance(bank_pid, account_id) do
+  end
+
+  @spec withdrawl(pid(), String.t(), pos_integer()) :: {:ok, {pos_integer(), pos_integer()}} | {:error, String.t()}
+  def withdrawl(bank_pid, account_id, amount) do
+  end
+
+  def init(initial_state) do
+    {:ok, initial_state}
+  end
+end

--- a/lessons/otp-concurrency/simple_bank/lib/simple_bank/account.ex
+++ b/lessons/otp-concurrency/simple_bank/lib/simple_bank/account.ex
@@ -1,0 +1,5 @@
+defmodule SimpleBank.Account do
+  @type t :: %__MODULE__{balance: integer(), id: String.t(), name: String.t()}
+
+  defstruct [:balance, :id, :name]
+end

--- a/lessons/otp-concurrency/simple_bank/mix.exs
+++ b/lessons/otp-concurrency/simple_bank/mix.exs
@@ -21,6 +21,7 @@ defmodule SimpleBank.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      { :elixir_uuid, "~> 1.2" }
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
     ]

--- a/lessons/otp-concurrency/simple_bank/mix.exs
+++ b/lessons/otp-concurrency/simple_bank/mix.exs
@@ -1,0 +1,28 @@
+defmodule SimpleBank.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :simple_bank,
+      version: "0.1.0",
+      elixir: "~> 1.6",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+    ]
+  end
+end

--- a/lessons/otp-concurrency/simple_bank/test/simple_bank_test.exs
+++ b/lessons/otp-concurrency/simple_bank/test/simple_bank_test.exs
@@ -1,0 +1,63 @@
+defmodule SimpleBankTest do
+  use ExUnit.Case, async: false
+
+  alias SimpleBank.Account
+
+  setup do
+    {:ok, bank_pid} = SimpleBank.start_link([%Account{balance: 100, id: "test_id", name: "Test"}])
+    {:ok, bank: bank_pid}
+  end
+
+  describe "register/2" do
+    test "creates a new account and generates an account id", %{bank: bank_pid} do
+      {:ok, account_id} = SimpleBank.register(bank_pid, "Another Test Account")
+      assert is_binary(account_id)
+    end
+
+    test "raises an error for existing account names", %{bank: bank_pid}  do
+      {:error, :existing_account} = SimpleBank.register(bank_pid, "Test")
+    end
+  end
+
+  describe "deposit/3" do
+    test "increases the account balance by the deposited amount", %{bank: bank_pid}  do
+      assert {:ok, 10} == SimpleBank.deposit(bank_pid, "test_id", 10)
+    end
+
+    test "does not allow deposits of negative amounts", %{bank: bank_pid}  do
+      assert {:error, :pos_integer_only} == SimpleBank.deposit(bank_pid, "test_id", -1)
+    end
+
+    test "raises an error if the account does not exist", %{bank: bank_pid}  do
+      assert {:error, :missing_account} == SimpleBank.deposit(bank_pid, "doesnotexist", 10)
+    end
+  end
+
+  describe "balance/2" do
+    test "returns the current account balance", %{bank: bank_pid}  do
+      assert {:ok, 110} == SimpleBank.deposit(bank_pid, "test_id", 10)
+    end
+
+    test "raises an error if the account does not exist", %{bank: bank_pid}  do
+      assert {:error, :missing_account} == SimpleBank.balance(bank_pid, "doesnotexist")
+    end
+  end
+
+  describe "withdrawl/3" do
+    test "decreases the account balance by the withdrawn amount", %{bank: bank_pid}  do
+      assert {:ok, 100} == SimpleBank.withdrawl(bank_pid, "test_id", 10)
+    end
+
+    test "does not negative ammount balances", %{bank: bank_pid}  do
+      assert {:error, :insufficient_funds} == SimpleBank.withdrawl(bank_pid, "test_id", -1)
+    end
+
+    test "does not allow withdrawls of negative amounts", %{bank: bank_pid}  do
+      assert {:error, :pos_integer_only} == SimpleBank.withdrawl(bank_pid, "test_id", 1000)
+    end
+
+    test "raises an error if the account does not exist", %{bank: bank_pid}  do
+      assert {:error, :missing_account} == SimpleBank.deposit(bank_pid, "doesnotexist", 10)
+    end
+  end
+end

--- a/lessons/otp-concurrency/simple_bank/test/simple_bank_test.exs
+++ b/lessons/otp-concurrency/simple_bank/test/simple_bank_test.exs
@@ -9,7 +9,7 @@ defmodule SimpleBankTest do
   end
 
   describe "register/2" do
-    test "creates a new account and generates an account id", %{bank: bank_pid} do
+    test "creates a new account with the given name and a randomly generated id. HINT: We've included the `elixir-uuid` dependency so that you can generate a random UUID string. See docs here https://github.com/zyro/elixir-uuid", %{bank: bank_pid} do
       {:ok, account_id} = SimpleBank.register(bank_pid, "Another Test Account")
       assert is_binary(account_id)
     end
@@ -21,7 +21,7 @@ defmodule SimpleBankTest do
 
   describe "deposit/3" do
     test "increases the account balance by the deposited amount", %{bank: bank_pid}  do
-      assert {:ok, 10} == SimpleBank.deposit(bank_pid, "test_id", 10)
+      assert {:ok, 110} == SimpleBank.deposit(bank_pid, "test_id", 10)
     end
 
     test "does not allow deposits of negative amounts", %{bank: bank_pid}  do
@@ -35,7 +35,7 @@ defmodule SimpleBankTest do
 
   describe "balance/2" do
     test "returns the current account balance", %{bank: bank_pid}  do
-      assert {:ok, 110} == SimpleBank.deposit(bank_pid, "test_id", 10)
+      assert {:ok, 100} == SimpleBank.balance(bank_pid, "test_id")
     end
 
     test "raises an error if the account does not exist", %{bank: bank_pid}  do
@@ -45,15 +45,15 @@ defmodule SimpleBankTest do
 
   describe "withdrawl/3" do
     test "decreases the account balance by the withdrawn amount", %{bank: bank_pid}  do
-      assert {:ok, 100} == SimpleBank.withdrawl(bank_pid, "test_id", 10)
+      assert {:ok, 90} == SimpleBank.withdrawl(bank_pid, "test_id", 10)
     end
 
     test "does not negative ammount balances", %{bank: bank_pid}  do
-      assert {:error, :insufficient_funds} == SimpleBank.withdrawl(bank_pid, "test_id", -1)
+      assert {:error, :insufficient_funds} == SimpleBank.withdrawl(bank_pid, "test_id", 1000)
     end
 
     test "does not allow withdrawls of negative amounts", %{bank: bank_pid}  do
-      assert {:error, :pos_integer_only} == SimpleBank.withdrawl(bank_pid, "test_id", 1000)
+      assert {:error, :pos_integer_only} == SimpleBank.withdrawl(bank_pid, "test_id", -1)
     end
 
     test "raises an error if the account does not exist", %{bank: bank_pid}  do

--- a/lessons/otp-concurrency/simple_bank/test/test_helper.exs
+++ b/lessons/otp-concurrency/simple_bank/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lessons/otp-concurrency/simple_bank/test/test_helper.exs
+++ b/lessons/otp-concurrency/simple_bank/test/test_helper.exs
@@ -1,1 +1,2 @@
+ExUnit.configure seed: 0 
 ExUnit.start()

--- a/lessons/otp-concurrency/simple_queue/.formatter.exs
+++ b/lessons/otp-concurrency/simple_queue/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lessons/otp-concurrency/simple_queue/.gitignore
+++ b/lessons/otp-concurrency/simple_queue/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+simple_queue-*.tar
+

--- a/lessons/otp-concurrency/simple_queue/README.md
+++ b/lessons/otp-concurrency/simple_queue/README.md
@@ -1,0 +1,23 @@
+# Simple Queue
+
+Hope you liked the OTP concurrency lesson. Here is your project for it!
+Look at the code in file `lib/simple_queue.exs`. It should be familiar, it's
+the same `SimpleQueue` implementation as in the lesson. Consider following
+modifications:
+
+1. Change the `enqueue` function from an asynchronous to a synchronous one.
+
+The function should preserve it's functionality, but
+return the new element instead of `:ok`. The unit tests
+could helpful if you get stack
+
+2. Implement a `sum_elements` function that will output a sum of all the numbers inside the queue
+
+The function should:
+- assume that every object in the queue is an integer
+- return an integer which is a sum of all numbers in the queue
+- not modify the state of the queue
+
+To run tests, make sure you `cd` into `homework/lessons/otp-concurrency/simple_queue` and execute `mix test`.
+
+If you get stuck, you can view the solution by checking out the `solution` branch of this repo!

--- a/lessons/otp-concurrency/simple_queue/lib/simple_queue.ex
+++ b/lessons/otp-concurrency/simple_queue/lib/simple_queue.ex
@@ -1,0 +1,25 @@
+defmodule SimpleQueue do
+  use GenServer
+
+  def init(state), do: {:ok, state}
+
+  def handle_call(:dequeue, _from, [value | state]) do
+    {:reply, value, state}
+  end
+
+  def handle_call(:dequeue, _from, []), do: {:reply, nil, []}
+
+  def handle_call(:queue, _from, state), do: {:reply, state, state}
+
+  def handle_cast({:enqueue, value}, state) do
+    {:noreply, state ++ [value]}
+  end
+
+  def start_link(state \\ []) do
+    GenServer.start_link(__MODULE__, state, name: __MODULE__)
+  end
+
+  def queue, do: GenServer.call(__MODULE__, :queue)
+  def enqueue(value), do: GenServer.cast(__MODULE__, {:enqueue, value})
+  def dequeue, do: GenServer.call(__MODULE__, :dequeue)
+end

--- a/lessons/otp-concurrency/simple_queue/mix.exs
+++ b/lessons/otp-concurrency/simple_queue/mix.exs
@@ -1,0 +1,28 @@
+defmodule SimpleQueue.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :simple_queue,
+      version: "0.1.0",
+      elixir: "~> 1.10",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/lessons/otp-concurrency/simple_queue/test/simple_queue_test.exs
+++ b/lessons/otp-concurrency/simple_queue/test/simple_queue_test.exs
@@ -1,0 +1,17 @@
+defmodule SimpleQueueTest do
+  use ExUnit.Case
+  doctest SimpleQueue
+
+  test "Task 1" do
+    SimpleQueue.start_link([1,2,3])
+    assert SimpleQueue.queue() == [1,2,3]
+    assert SimpleQueue.enqueue(20) == 20
+    assert SimpleQueue.queue() == [1,2,3,20]
+  end
+
+  test "Task 2" do
+    SimpleQueue.start_link([1,2,3,4,5,6,7])
+    assert SimpleQueue.sum() == 28
+    assert SimpleQueue.queue() == [1,2,3,4,5,6,7] # State is not modified
+  end
+end

--- a/lessons/otp-concurrency/simple_queue/test/test_helper.exs
+++ b/lessons/otp-concurrency/simple_queue/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
Per this issue https://github.com/elixirschool/elixirschool/issues/2295, this PR adds homework for the OTP Concurrency lesson on elixirschool.com. 

We will close the original PR that added assignments to the `elixirschool/elixirschool` repo in favor of placing test-driven homework assignments in this repo. 

This PR:
* Adds a new directory, `lessons/`, under which we will place all homework assignments that correspond to Elixir School lessons
* Introduces a new homework assignment `lessons/otp-concurrency/simple-queue` with a test suite
* Moves the `simple_bank` assignment into` lessons/otp-concurrency/simple-bank`
* Provides some fixes to the simple bank starter-code and test suite 
* Adds a README for each homework assignment in their respective directories

The solutions for both assignments can be found on the [solution branch](https://github.com/elixirschool/homework/tree/solution) 